### PR TITLE
Add common iterator functions to read through native Scilla values

### DIFF
--- a/libScillaRTL/SRTL.cpp
+++ b/libScillaRTL/SRTL.cpp
@@ -114,28 +114,16 @@ bool dynamicTypecheck(const ScillaExecImpl *SJ, const ScillaTypes::Typ *TargetT,
         case Typ::Prim_typ:
           return true;
         case Typ::ADT_typ: {
-          const ScillaTypes::ADTTyp::Specl *Specl = ExpectedT->m_sub.m_spladt;
-          auto VP = reinterpret_cast<const uint8_t *>(Val);
-          auto Tag = *VP;
-          // Increment VP once to go past the Tag.
-          VP++;
-          auto ConstrP = Specl->m_constrs[Tag];
-          // Check all arguments of this ADT constructor.
-          for (int I = 0; I < ConstrP->m_numArgs; I++) {
-            auto *ArgT = ConstrP->m_args[I];
-            if (ScillaTypes::Typ::isBoxed(ArgT)) {
-              if (!recurser(ArgT, *reinterpret_cast<const void *const *>(VP)))
-                return false;
-            } else {
-              if (!recurser(ArgT, reinterpret_cast<const void *>(VP)))
-                return false;
-            }
-            // Increment our data pointer equal to the size we just finised.
-            // structs containing ADTs are packed, so that we don't have to
-            // worry about padding here.
-            VP += ScillaTypes::Typ::sizeOf(ArgT);
-          }
-          return true;
+          bool Res = true;
+          ScillaValues::iterScillaADTConstrArgs(
+              ExpectedT, Val,
+              [&recurser, &Res](const ScillaTypes::Typ *T, const void *V) {
+                if (!Res) {
+                  return;
+                }
+                Res = recurser(T, V);
+              });
+          return Res;
         }
         case Typ::Map_typ: {
           ScillaTypes::MapTyp *MT = ExpectedT->m_sub.m_mapt;
@@ -190,6 +178,6 @@ bool dynamicTypecheck(const ScillaExecImpl *SJ, const ScillaTypes::Typ *TargetT,
       };
 
   return recurser(TargetT, Val);
-}
+} // namespace ScillaRTL
 
 } // namespace ScillaRTL

--- a/libScillaRTL/SRTL.cpp
+++ b/libScillaRTL/SRTL.cpp
@@ -178,6 +178,6 @@ bool dynamicTypecheck(const ScillaExecImpl *SJ, const ScillaTypes::Typ *TargetT,
       };
 
   return recurser(TargetT, Val);
-} // namespace ScillaRTL
+}
 
 } // namespace ScillaRTL

--- a/libScillaRTL/ScillaValue.cpp
+++ b/libScillaRTL/ScillaValue.cpp
@@ -317,38 +317,25 @@ Json::Value toJSON(const ScillaTypes::Typ *T, const void *V) {
         default:
           CREATE_ERROR("Unreachable");
         }
-        auto V_UC = reinterpret_cast<const uint8_t *>(V);
-        int NFields = *(V_UC++);
-
         Out["params"] = Json::arrayValue;
-        for (int I = 0; I < NFields; I++) {
-          // 1. Field's name.
-          auto *FNameP = reinterpret_cast<const ScillaTypes::String *>(V_UC);
-          auto FName = FNameP->operator std::string();
-          V_UC += sizeof(ScillaTypes::String);
-          // 2. Type descriptor for the value.
-          auto *TD = *reinterpret_cast<const ScillaTypes::Typ *const *>(V_UC);
-          V_UC += sizeof(const ScillaTypes::Typ *);
-          // 3. The value itself.
-          Json::Value VJ;
-          if (ScillaTypes::Typ::isBoxed(TD)) {
-            recurser(TD, *reinterpret_cast<const void *const *>(V_UC), VJ);
-          } else {
-            recurser(TD, V_UC, VJ);
-          }
-          V_UC += ScillaTypes::Typ::sizeOf(TD);
-          // Bundle all the data into E.
-          if (FName == Name || (Name == "_tag" && (FName == "_recipient" ||
-                                                   FName == "_amount"))) {
-            Out[FName] = VJ;
-          } else {
-            Json::Value VV;
-            VV["vname"] = FName;
-            VV["type"] = ScillaTypes::Typ::toString(TD);
-            VV["value"] = VJ;
-            Out["params"].append(VV);
-          }
-        }
+        iterScillaMsgObjectElms(
+            T, V,
+            [&recurser, &Out, &Name](const ScillaTypes::Typ *T, const void *V,
+                                     const std::string &FName) {
+              Json::Value VJ;
+              recurser(T, V, VJ);
+              // Bundle all the data into E.
+              if (FName == Name || (Name == "_tag" && (FName == "_recipient" ||
+                                                       FName == "_amount"))) {
+                Out[FName] = VJ;
+              } else {
+                Json::Value VV;
+                VV["vname"] = FName;
+                VV["type"] = ScillaTypes::Typ::toString(T);
+                VV["value"] = VJ;
+                Out["params"].append(VV);
+              }
+            });
         break;
       }
       }
@@ -739,31 +726,14 @@ uint64_t literalCost(const ScillaTypes::Typ *T, const void *V) {
     case ScillaTypes::PrimTyp::Msg_typ:
     case ScillaTypes::PrimTyp::Event_typ:
     case ScillaTypes::PrimTyp::Exception_typ: {
-      if (!V) {
-        ASSERT(T->m_sub.m_primt->m_pt == ScillaTypes::PrimTyp::Exception_typ);
-        return 0;
-      }
-
-      auto V_UC = reinterpret_cast<const uint8_t *>(V);
-      int NFields = *(V_UC++);
-
       uint64_t Acc = 0;
-      for (int I = 0; I < NFields; I++) {
-        // 1. Field's name.
-        auto *FNameP = reinterpret_cast<const ScillaTypes::String *>(V_UC);
-        Acc += stringLengthNormalize(FNameP->m_length);
-        V_UC += sizeof(ScillaTypes::String);
-        // 2. Type descriptor for the value.
-        auto *TD = *reinterpret_cast<const ScillaTypes::Typ *const *>(V_UC);
-        V_UC += sizeof(const ScillaTypes::Typ *);
-        // 3. The value itself.
-        if (ScillaTypes::Typ::isBoxed(TD)) {
-          Acc += literalCost(TD, *reinterpret_cast<const void *const *>(V_UC));
-        } else {
-          Acc += literalCost(TD, V_UC);
-        }
-        V_UC += ScillaTypes::Typ::sizeOf(TD);
-      }
+      iterScillaMsgObjectElms(T, V,
+                              [&Acc, &stringLengthNormalize](
+                                  const ScillaTypes::Typ *T, const void *V,
+                                  const std::string &FName) {
+                                Acc += stringLengthNormalize(FName.size());
+                                Acc += literalCost(T, V);
+                              });
       return Acc;
     }
     }
@@ -864,6 +834,45 @@ void iterScillaADTConstrArgs(const ScillaTypes::Typ *T, const void *V,
     // structs containing ADTs are packed, so that we don't have to
     // worry about padding here.
     VP += ScillaTypes::Typ::sizeOf(ArgT);
+  }
+}
+
+void iterScillaMsgObjectElms(const ScillaTypes::Typ *T, const void *V,
+                             ScillaNamedValueCallback F) {
+
+  ASSERT(T->m_t == ScillaTypes::Typ::Prim_typ);
+  switch (T->m_sub.m_primt->m_pt) {
+  case ScillaTypes::PrimTyp::Msg_typ:
+  case ScillaTypes::PrimTyp::Event_typ:
+  case ScillaTypes::PrimTyp::Exception_typ: {
+    if (!V) {
+      ASSERT(T->m_sub.m_primt->m_pt == ScillaTypes::PrimTyp::Exception_typ);
+      return;
+    }
+  } break;
+  default:
+    CREATE_ERROR("Expected Scilla Message object");
+  }
+
+  auto V_UC = reinterpret_cast<const uint8_t *>(V);
+  int NFields = *(V_UC++);
+
+  for (int I = 0; I < NFields; I++) {
+    // 1. Field's name.
+    auto *FNameP = reinterpret_cast<const ScillaTypes::String *>(V_UC);
+    auto FName = FNameP->operator std::string();
+    V_UC += sizeof(ScillaTypes::String);
+    // 2. Type descriptor for the value.
+    auto *TD = *reinterpret_cast<const ScillaTypes::Typ *const *>(V_UC);
+    V_UC += sizeof(const ScillaTypes::Typ *);
+    // 3. The value itself.
+    Json::Value VJ;
+    if (ScillaTypes::Typ::isBoxed(TD)) {
+      F(TD, *reinterpret_cast<const void *const *>(V_UC), FName);
+    } else {
+      F(TD, V_UC, FName);
+    }
+    V_UC += ScillaTypes::Typ::sizeOf(TD);
   }
 }
 

--- a/libScillaRTL/ScillaValue.h
+++ b/libScillaRTL/ScillaValue.h
@@ -67,13 +67,22 @@ void serializeForHashing(ByteVec &Ret, const ScillaTypes::Typ *T,
 // Compatible with literal_cost in Gas.ml in Scilla_base.
 uint64_t literalCost(const ScillaTypes::Typ *T, const void *V);
 
+using ScillaValueCallback =
+    std::function<void(const ScillaTypes::Typ *T, const void *)>;
+
+// Iterate over the constructor arguments of a Scilla ADT value,
+// calling back F for each argument, also passing the argument's type.
+// As usual:
+//  - for boxed values, the pointer passed is the boxing pointer.
+//  - for non-boxed values, their address is passed and must be loaded from.
+void iterScillaADTConstrArgs(const ScillaTypes::Typ *T, const void *V,
+                             ScillaValueCallback F);
+
 // Iterate over a Scilla list, apply F to each element.
 // F is passed the element type and the element.
 // As usual:
 //  - for boxed values, the pointer passed is the boxing pointer.
 //  - for non-boxed values, their address is passed and must be loaded from.
-using ScillaValueCallback =
-    std::function<void(const ScillaTypes::Typ *T, const void *)>;
 void iterScillaList(const ScillaTypes::Typ *T, const void *V,
                     ScillaValueCallback F);
 

--- a/libScillaRTL/ScillaValue.h
+++ b/libScillaRTL/ScillaValue.h
@@ -86,5 +86,16 @@ void iterScillaADTConstrArgs(const ScillaTypes::Typ *T, const void *V,
 void iterScillaList(const ScillaTypes::Typ *T, const void *V,
                     ScillaValueCallback F);
 
+using ScillaNamedValueCallback = std::function<void(
+    const ScillaTypes::Typ *T, const void *, const std::string &)>;
+
+// Iterate over the fields of a Scilla Msg object, apply F to each field.
+// F is passed the element type, the element and the field name.
+// As usual:
+//  - for boxed values, the pointer passed is the boxing pointer.
+//  - for non-boxed values, their address is passed and must be loaded from.
+void iterScillaMsgObjectElms(const ScillaTypes::Typ *T, const void *V,
+                             ScillaNamedValueCallback F);
+
 } // namespace ScillaValues
 } // namespace ScillaRTL


### PR DESCRIPTION
The following are added. This enables code re-use, and avoids mistakes in dealing with memory buffers representing Scilla values.

- Generic iterators for ADT values
- Generic iterators for Msg (Message / Event / Exception) objects