### PR TITLE
Move to clang-12 for compiling LLVM to binary

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -20,8 +20,11 @@ jobs:
         with:
           submodules: 'recursive'
 
+      - name: Install LLVM repositories
+        run: sudo add-apt-repository -y 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main'
+
       - name: Install required OS packages
-        run: sudo apt-get update && sudo apt-get install -yq build-essential pkg-config zlib1g-dev libssl-dev libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-system-dev libboost-test-dev libjsoncpp-dev libsecp256k1-dev clang-10 
+        run: sudo apt-get update && sudo apt-get install -yq build-essential pkg-config zlib1g-dev libssl-dev libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-system-dev libboost-test-dev libjsoncpp-dev libsecp256k1-dev clang-12
 
       - name: ScillaRTL Testsuite Release Build
         run: scripts/build_ci.sh

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ The Scilla Runtime Library provides two main functionalities
 ## Build and install
 
 Install these Ubuntu packages
-  - `sudo apt-get install build-essential clang-10 cmake libboost-dev libboost-test-dev libjsoncpp-dev libboost-filesystem-dev libboost-program-options-dev libsecp256k1-dev`
+  - `sudo apt-get install build-essential clang-12 cmake libboost-dev libboost-test-dev libjsoncpp-dev libboost-filesystem-dev libboost-program-options-dev libsecp256k1-dev`
 
-Use the LLVM apt repository if clang-10 is not in your OS repository.
+Use the LLVM apt repository if clang-12 is not in your OS repository.
 
 We suggest building ScillaRTL in a directory that is *not* the source directory.
   * `$git clone --recurse-submodules https://github.com/Zilliqa/scilla-rtl.git`

--- a/libScillaRTL/Utils.cpp
+++ b/libScillaRTL/Utils.cpp
@@ -111,7 +111,7 @@ uint64_t parseBlockchainJSON(const Json::Value &BC) {
 void compileLLVMToSO(const std::string &InputFile,
                      const std::string &OutputFile) {
   try {
-    auto ExecP = bp::search_path("clang-10");
+    auto ExecP = bp::search_path("clang-12");
     if (bp::system(ExecP, "-Wno-override-module", "-fPIC", "-shared", InputFile,
                    "-o", OutputFile)) {
       CREATE_ERROR("Compilation of " + InputFile + " failed.");


### PR DESCRIPTION
While adding support for gas charges for builtin operations (WIP), I realized that `llvm.umin.i64` isn't supported on clang-10 at all. Hence the upgrade.